### PR TITLE
fix: fix typo in aws cluster config.

### DIFF
--- a/src/cloud/aws/cluster_config.yaml
+++ b/src/cloud/aws/cluster_config.yaml
@@ -28,7 +28,7 @@ addons:
   - name: amazon-cloudwatch-observability
     version: latest
 
-mangedNodeGroups:
+managedNodeGroups:
   - name: diarkis-public
     instanceType: m5.large
     volumeSize: 100

--- a/src/script/setup_gcp.sh
+++ b/src/script/setup_gcp.sh
@@ -15,4 +15,4 @@ else
     echo "Unsupported OS"
     uname -a
     exit 1
-end
+fi


### PR DESCRIPTION
インフラ構成スクリプトと定義ファイルの以下を修正しました
- aws cluster config の `managedNodeGroups` の typo
- `setup_gcp.sh` の if 文の閉じる宣言が `end` になっていたのを `fi` に修正