### PR TITLE
improvement: update README on how to deploy AWS and tweak settings.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -8,6 +8,9 @@ help:
 DIARKIS_VERSION = $(shell go list -m github.com/Diarkis/diarkis | cut -d " " -f 2)
 DIARKIS_CLI = ./diarkis-cli/os/linux/bin/diarkis-cli
 BUILD_CONFIG = ./build/linux-build.yml
+AWS_ACCOUNT_NUM = __AWS_ACCOUNT_NUM__
+GCP_PROJECT_ID = __GCP_PROJECT_ID__
+ACR_DOMAIN = __ACR_DOMAIN__
 
 ifeq ($(shell uname), Darwin)
 	DIARKIS_CLI = ./diarkis-cli/os/mac/bin/diarkis-cli
@@ -73,19 +76,23 @@ stop-docker: ## Stop Diarkis
 setup-aws:
 	./script/setup_aws.sh
 
+.PHONY: auth-docker-aws
+auth-docker-aws:
+	aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin $(AWS_ACCOUNT_NUM).dkr.ecr.ap-northeast-1.amazonaws.com
+
 .PHONY: build-container-aws
 build-container-aws: build-linux ## Build container for AWS
-	docker build --platform=linux/amd64 -f docker/http/Dockerfile remote_bin -t __AWS_ACCOUNT_NUM__.dkr.ecr.ap-northeast-1.amazonaws.com/http
-	docker build --platform=linux/amd64 -f docker/udp/Dockerfile remote_bin -t __AWS_ACCOUNT_NUM__.dkr.ecr.ap-northeast-1.amazonaws.com/udp
-	docker build --platform=linux/amd64 -f docker/tcp/Dockerfile remote_bin -t __AWS_ACCOUNT_NUM__.dkr.ecr.ap-northeast-1.amazonaws.com/tcp
-	docker build --platform=linux/amd64 -f docker/mars/Dockerfile remote_bin -t __AWS_ACCOUNT_NUM__.dkr.ecr.ap-northeast-1.amazonaws.com/mars
+	docker build --platform=linux/amd64 -f docker/http/Dockerfile remote_bin -t $(AWS_ACCOUNT_NUM).dkr.ecr.ap-northeast-1.amazonaws.com/http
+	docker build --platform=linux/amd64 -f docker/udp/Dockerfile remote_bin -t $(AWS_ACCOUNT_NUM).dkr.ecr.ap-northeast-1.amazonaws.com/udp
+	docker build --platform=linux/amd64 -f docker/tcp/Dockerfile remote_bin -t $(AWS_ACCOUNT_NUM).dkr.ecr.ap-northeast-1.amazonaws.com/tcp
+	docker build --platform=linux/amd64 -f docker/mars/Dockerfile remote_bin -t $(AWS_ACCOUNT_NUM).dkr.ecr.ap-northeast-1.amazonaws.com/mars
 
 .PHONY: push-container-aws
 push-container-aws: ## Push container to AWS
-	docker push __AWS_ACCOUNT_NUM__.dkr.ecr.ap-northeast-1.amazonaws.com/http
-	docker push __AWS_ACCOUNT_NUM__.dkr.ecr.ap-northeast-1.amazonaws.com/udp
-	docker push __AWS_ACCOUNT_NUM__.dkr.ecr.ap-northeast-1.amazonaws.com/tcp
-	docker push __AWS_ACCOUNT_NUM__.dkr.ecr.ap-northeast-1.amazonaws.com/mars
+	docker push $(AWS_ACCOUNT_NUM).dkr.ecr.ap-northeast-1.amazonaws.com/http
+	docker push $(AWS_ACCOUNT_NUM).dkr.ecr.ap-northeast-1.amazonaws.com/udp
+	docker push $(AWS_ACCOUNT_NUM).dkr.ecr.ap-northeast-1.amazonaws.com/tcp
+	docker push $(AWS_ACCOUNT_NUM).dkr.ecr.ap-northeast-1.amazonaws.com/mars
 
 .PHONY: setup-gcp
 setup-gcp: ## Set up GCP
@@ -93,17 +100,17 @@ setup-gcp: ## Set up GCP
 
 .PHONY: build-container-gcp
 build-container-gcp: build-linux ## Build container for GCP
-	docker build --platform=linux/amd64 -f docker/http/Dockerfile remote_bin -t asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/http
-	docker build --platform=linux/amd64 -f docker/udp/Dockerfile remote_bin -t  asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/udp
-	docker build --platform=linux/amd64 -f docker/tcp/Dockerfile remote_bin -t  asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/tcp
-	docker build --platform=linux/amd64 -f docker/mars/Dockerfile remote_bin -t  asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/mars
+	docker build --platform=linux/amd64 -f docker/http/Dockerfile remote_bin -t asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/http
+	docker build --platform=linux/amd64 -f docker/udp/Dockerfile remote_bin -t  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/udp
+	docker build --platform=linux/amd64 -f docker/tcp/Dockerfile remote_bin -t  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/tcp
+	docker build --platform=linux/amd64 -f docker/mars/Dockerfile remote_bin -t  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/mars
 
 .PHONY: push-container-gcp
 push-container-gcp: ## Push container to GCP
-	docker push  asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/http
-	docker push  asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/udp
-	docker push  asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/tcp
-	docker push  asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/mars
+	docker push  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/http
+	docker push  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/udp
+	docker push  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/tcp
+	docker push  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/mars
 
 .PHONY: setup-azure
 setup-azure: ## Set up Azure
@@ -112,14 +119,14 @@ setup-azure: ## Set up Azure
 
 .PHONY: build-container-azure
 build-container-azure: build-linux ## Build container for azure
-	docker build --platform=linux/amd64 -f docker/http/Dockerfile remote_bin -t __ACR_DOMAIN__/http
-	docker build --platform=linux/amd64 -f docker/udp/Dockerfile remote_bin -t  __ACR_DOMAIN__/udp
-	docker build --platform=linux/amd64 -f docker/tcp/Dockerfile remote_bin -t  __ACR_DOMAIN__/tcp
-	docker build --platform=linux/amd64 -f docker/mars/Dockerfile remote_bin -t __ACR_DOMAIN__/mars
+	docker build --platform=linux/amd64 -f docker/http/Dockerfile remote_bin -t $(ACR_DOMAIN)/http
+	docker build --platform=linux/amd64 -f docker/udp/Dockerfile remote_bin -t  $(ACR_DOMAIN)/udp
+	docker build --platform=linux/amd64 -f docker/tcp/Dockerfile remote_bin -t  $(ACR_DOMAIN)/tcp
+	docker build --platform=linux/amd64 -f docker/mars/Dockerfile remote_bin -t $(ACR_DOMAIN)/mars
 
 .PHONY: push-container-azure
 push-container-azure: ## Push container to azure
-	docker push __ACR_DOMAIN__/http
-	docker push __ACR_DOMAIN__/udp
-	docker push __ACR_DOMAIN__/tcp
-	docker push __ACR_DOMAIN__/mars
+	docker push $(ACR_DOMAIN)/http
+	docker push $(ACR_DOMAIN)/udp
+	docker push $(ACR_DOMAIN)/tcp
+	docker push $(ACR_DOMAIN)/mars

--- a/src/Makefile
+++ b/src/Makefile
@@ -88,7 +88,7 @@ build-container-aws: build-linux ## Build container for AWS
 	docker build --platform=linux/amd64 -f docker/mars/Dockerfile remote_bin -t $(AWS_ACCOUNT_NUM).dkr.ecr.ap-northeast-1.amazonaws.com/mars
 
 .PHONY: push-container-aws
-push-container-aws: ## Push container to AWS
+push-container-aws: auth-docker-aws ## Push container to AWS
 	docker push $(AWS_ACCOUNT_NUM).dkr.ecr.ap-northeast-1.amazonaws.com/http
 	docker push $(AWS_ACCOUNT_NUM).dkr.ecr.ap-northeast-1.amazonaws.com/udp
 	docker push $(AWS_ACCOUNT_NUM).dkr.ecr.ap-northeast-1.amazonaws.com/tcp

--- a/src/cloud/aws/README.md
+++ b/src/cloud/aws/README.md
@@ -45,31 +45,27 @@ aws eks --region ap-northeast-1 update-kubeconfig --name diarkis # get credetial
 
 ## 5. Open EKS firewall
 
-EKSのNodeに対してfirewallで、0.0.0.0/0からtcp,udpの7000-8000を開放する
+EKSのNodeに対してfirewallで、0.0.0.0/0からtcp,udpの7000-8000を開放します。
+
+eks-cluster-sg-diarkis-* のようなセキュリティグループが作成されているので、それに対して設定を行ってください。
 
 ## 6. tagging the server image and push
 
-server-templateから生成した project の root から下記を実行
+server-templateから生成した project の root から下記を実行します。
 ※ 詳細は[こちら](https://help.diarkis.io/ja/running-diarkis-server-on-local)をご覧ください。
 
 ```
 make build-local
 ```
 
-./remote_bin にサーバーの実行ファイル郡(udp, tcp, http, mars)が生成された後、コンテナイメージをビルド
+./remote_bin にサーバーの実行ファイル郡(udp, tcp, http, mars)が生成された後、コンテナイメージをビルドします。
 
 ```
 make setup-aws
 make build-container-aws
 ```
 
-dockerに認証を通す
-
-```
-aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin ${AWS_ACCOUNT_NUM}.dkr.ecr.ap-northeast-1.amazonaws.com
-```
-
-imageをpush
+imageをpushします。
 
 ```
 make push-container-aws
@@ -94,23 +90,23 @@ udp-fdc6bbccc-dwc5w     1/1     Running   0          3d14h
 
 ## 8. check diarkis cluster
 
-まずpublic endpointを取得する
+まずpublic endpointを取得します。
 
 ```
 EXTERNAL_IP=$(kubectl get svc http -o json -n dev0 | jq -r '.status.loadBalancer.ingress[].hostname')
 kubectl get svc -n dev0 -o wide # このコマンドで表示されるEXTERNAL IPと同一なのでどちらで見ていただいても構いません。
 ```
 
-取得できたEXTERNAL-IPに対してAPIを叩く
+取得できたEXTERNAL-IPに対して HTTP GET リクエストを送信します。
 
 ```
 curl ${EXTERNAL_IP}/auth/1
 ```
 
-下記の様なレスポンスが返ってくればOK
+下記の様なレスポンスが返ってくればOKです。
 
 ```
-{"TCP":"ec2-xx-xx-xx-xx.ap-northeast-1.compute.amazonaws.com:7201","UDP":"ec2-yy-yy-yy-yy.ap-northeast-1.compute.amazonaws.com:7101","sid":"xxxxxxxxxx","encryptionKey":"xxxxxxxxxx","encryptionIV":"xxxxxxxxxx","encryptionMacKey":"xxxxxxxxxx"}%
+{"TCP":"ec2-xx-xx-xx-xx.ap-northeast-1.compute.amazonaws.com:7201","UDP":"ec2-yy-yy-yy-yy.ap-northeast-1.compute.amazonaws.com:7101","sid":"xxxxxxxxxx","encryptionKey":"xxxxxxxxxx","encryptionIV":"xxxxxxxxxx","encryptionMacKey":"xxxxxxxxxx"}
 ```
 
 抜けている項目等があれば、何かのコンポーネントに異常をきたしている可能性があるため、お問合せください。

--- a/src/cloud/aws/README.md
+++ b/src/cloud/aws/README.md
@@ -47,7 +47,7 @@ aws eks --region ap-northeast-1 update-kubeconfig --name diarkis # get credetial
 
 EKSのNodeに対してfirewallで、0.0.0.0/0からtcp,udpの7000-8000を開放します。
 
-eks-cluster-sg-diarkis-* のようなセキュリティグループが作成されているので、それに対して設定を行ってください。
+eks-cluster-sg-diarkis-\* のようなセキュリティグループが作成されているので、それに対して設定を行ってください。
 
 ## 6. tagging the server image and push
 

--- a/src/cloud/aws/cluster_config.yaml
+++ b/src/cloud/aws/cluster_config.yaml
@@ -4,6 +4,7 @@ kind: ClusterConfig
 metadata:
   name: diarkis
   region: ap-northeast-1
+  version: "1.29"
 vpc:
   clusterEndpoints:
     privateAccess: true

--- a/src/k8s/aws/overlays/dev0/udp/conf/main.json
+++ b/src/k8s/aws/overlays/dev0/udp/conf/main.json
@@ -1,5 +1,5 @@
 {
-  "enableP2P": false,
+  "enableP2P": true,
   "connectionTTL": 10,
   "sendUDPInterval": 50,
   "handleRUDPInterval": 100,


### PR DESCRIPTION
概要
==

AWS の README のアップデートと設定の調整をしました

- make に `auth-docker-aws` タスクを追加。 `push-container-aws` をする前に認証するようにした
- Makefile 内のクラウドごとに置換される文字列を変数に切り出しました
- AWS README の修正。
- AWS eksctl の config で kubernetes のバージョンを `1.29` に固定するようにした
  - `1.30` にすると、NIC が private ではeth0 のままだが、 public では ens5 になったため、一旦以前のバージョンに固定化。調整は別途実施する
- dev0 環境で P2P を enabled にした（他のクラウドの設定と合わせた）
