### PR TITLE
feat: added Go test client.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -64,6 +64,10 @@ gen: ## Generate go, cpp, and cs code files using puffer (Diarkis packet gen mod
 clean: ## Deletes all puffer generated code files
 	make -C puffer clean
 
+.PHONY: go-cli
+go-cli: ## Starts Go test client: host=<HTTP address> uid=<client user ID> clientKey=<client key> puffer=<true/false>
+	./remote_bin/testcli --host=$(host) --uid=$(uid) --clientKey=$(clientKey) --puffer=$(puffer)
+
 .PHONY: run-docker
 run-docker: build-linux ## Run Diarkis locally with docker compose
 	docker compose up -d

--- a/src/README.md
+++ b/src/README.md
@@ -21,9 +21,9 @@ Only HTTP server is required in the cluster and the rest of the servers should b
    │
    ├─ mars/ ───────── main.go
    │
-   │
    ├─ healthcheck/ ── main.go
    │
+   ├─ testcli/ ── main.go [Go test client main]
    │
    ├─ configs/ ─┬──── shared/ [Shared configuration directory] ────────────────────┬─ field.json
    │            │                                                                  ├─ dm.json
@@ -102,6 +102,22 @@ make stop-docker
 ```
 
 **NOTE** You must have MARS and HTTP server running in order to create Diarkis server cluster properly.
+
+# Run Go Test Client
+
+The following command will run the Go test client.
+
+```
+make go-cli host=$(host) uid=$(uid)
+```
+
+After running the command, you can show the help message by running the following command:
+
+```
+help
+# to show each module's help message
+help $(module)
+```
 
 # Change Diarkis version
 

--- a/src/build/linux-build.yml
+++ b/src/build/linux-build.yml
@@ -23,6 +23,9 @@ buildSettings:
     health-check:
       target: healthcheck/main.go
       output: remote_bin/health-check
+    testcli:
+      target: testcli/main.go
+      output: remote_bin/testcli
 diarkis:
   project_id: "{{PROJECT_ID}}"
   builder_token: "{{BUILD_TOKEN}}"

--- a/src/build/mac-build.yml
+++ b/src/build/mac-build.yml
@@ -25,6 +25,9 @@ buildSettings:
     ms:
       target: mars-stats/main.go
       output: remote_bin/ms
+    testcli:
+      target: testcli/main.go
+      output: remote_bin/testcli
 diarkis:
   project_id: "{{PROJECT_ID}}"
   builder_token: "{{BUILD_TOKEN}}"

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,4 +1,5 @@
 module github.com/Diarkis/diarkis-server-template
 
 go 1.22
-require github.com/Diarkis/diarkis v1.0.0
+
+require github.com/Diarkis/diarkis v1.1.0-alpha1

--- a/src/testcli/main.go
+++ b/src/testcli/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/Diarkis/diarkis-server-template/testcli/resonance"
+	"github.com/Diarkis/diarkis/client/go/test/cli"
+)
+
+var (
+	tcpResonance *resonance.Resonance
+	udpResonance *resonance.Resonance
+)
+
+func main() {
+	cli.SetupBuiltInCommands()
+
+	// You can add custom commands to the CLI.
+	cli.RegisterCommands("test", []cli.Command{
+		{CmdName: "resonate", Desc: "Resonate your message", CmdFunc: resonate},
+	})
+
+	cli.Connect()
+
+	// setup custom module
+	if cli.TCPClient != nil {
+		tcpResonance = resonance.SetupAsTCP(cli.TCPClient)
+	}
+	if cli.UDPClient != nil {
+		udpResonance = resonance.SetupAsUDP(cli.UDPClient)
+	}
+
+	cli.Run()
+}
+
+func resonate() {
+	// This is a sample command to add test commands to the CLI.
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("Which client to join a room? [tcp/udp]")
+	client, _ := reader.ReadString('\n')
+
+	fmt.Println("Enter the message you want to resonate.")
+	message, _ := reader.ReadString('\n')
+
+	switch client {
+	case "tcp\n":
+		if tcpResonance == nil {
+			return
+		}
+		tcpResonance.Resonate(message)
+	case "udp\n":
+		if udpResonance == nil {
+			return
+		}
+		udpResonance.Resonate(message)
+	}
+}

--- a/src/testcli/main.go
+++ b/src/testcli/main.go
@@ -1,3 +1,5 @@
+// © 2019-2024 Diarkis Inc. All rights reserved.
+
 package main
 
 import (

--- a/src/testcli/resonance/resonance.go
+++ b/src/testcli/resonance/resonance.go
@@ -1,0 +1,62 @@
+package resonance
+
+import (
+	"fmt"
+
+	"github.com/Diarkis/diarkis/client/go/tcp"
+	"github.com/Diarkis/diarkis/client/go/udp"
+)
+
+const (
+	version        uint8  = 2
+	resonanceCmdID uint16 = 13
+)
+
+type Resonance struct {
+	tcp *tcp.Client
+	udp *udp.Client
+}
+
+func SetupAsTCP(c *tcp.Client) *Resonance {
+	r := &Resonance{tcp: c}
+	r.setup()
+	return r
+}
+
+func SetupAsUDP(c *udp.Client) *Resonance {
+	r := &Resonance{udp: c}
+	r.setup()
+	return r
+}
+
+func (r *Resonance) setup() {
+	if r.tcp != nil {
+		r.tcp.OnResponse(r.onResponse)
+		return
+	}
+	if r.udp != nil {
+		r.udp.OnResponse(r.onResponse)
+	}
+}
+
+func (r *Resonance) onResponse(ver uint8, cmd uint16, status uint8, payload []byte) {
+	if ver != version || cmd != resonanceCmdID {
+		return
+	}
+
+	fmt.Printf("Resonance command response: %v\n", string(payload))
+}
+
+func (r *Resonance) Send(cmd uint16, payload []byte) {
+	if r.tcp != nil {
+		r.tcp.Send(version, resonanceCmdID, payload)
+		return
+	}
+	if r.udp != nil {
+		r.udp.Send(version, resonanceCmdID, payload)
+	}
+}
+
+func (r *Resonance) Resonate(message string) {
+	r.Send(resonanceCmdID, []byte(message))
+}

--- a/src/testcli/resonance/resonance.go
+++ b/src/testcli/resonance/resonance.go
@@ -1,3 +1,5 @@
+// © 2019-2024 Diarkis Inc. All rights reserved.
+
 package resonance
 
 import (


### PR DESCRIPTION
概要
===

Go の test client を追加しました
- diarkis-cli でビルドするときに、合わせて test client をビルドするようにしました
- `make go-cli` にて Go test client を実行できるようにしました
