### PR TITLE
Remove UE specific logic

### DIFF
--- a/src/cmds/room/main.go
+++ b/src/cmds/room/main.go
@@ -1,13 +1,11 @@
 package roomcmds
 
 import (
-	"encoding/binary"
 	"github.com/Diarkis/diarkis-server-template/lib/meshCmds"
 	"github.com/Diarkis/diarkis/log"
 	"github.com/Diarkis/diarkis/room"
 	"github.com/Diarkis/diarkis/roomsupport"
 	"github.com/Diarkis/diarkis/user"
-	"strconv"
 )
 
 const ver uint8 = 3
@@ -32,15 +30,7 @@ func Setup() {
 
 func onDiscardCustomMessage(roomID string, userID string, sid string) []byte {
 	logger.Debug("OnDiscardCustomMessage roomID:%v userID:%v sid:%v", roomID, userID, sid)
-	// UE4 sample client uses uin64 as the data type for userID
-	conv, err := strconv.ParseUint(userID, 10, 64)
-	if err != nil {
-		return []byte(userID)
-	}
-	bytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(bytes, uint64(conv))
-	logger.Debug("OnDiscardCustomMessage message user ID %v bytes %v", conv, bytes)
-	return bytes
+	return []byte(userID)
 }
 
 func onRoomOwnerChange(roomID string, ownerID string) {

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,5 +1,4 @@
 module github.com/Diarkis/diarkis-server-template
 
 go 1.22
-replace github.com/Diarkis/diarkis => /Users/kairi/diarkis
 require github.com/Diarkis/diarkis v1.0.0-rc1


### PR DESCRIPTION
When you send a Room Leave message, there was a logic that converts user name into int if parsable which is dedicated for UE.