### PR TITLE
build: bump up v1.0.0

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,4 +1,4 @@
 module github.com/Diarkis/diarkis-server-template
 
 go 1.22
-require github.com/Diarkis/diarkis v1.0.0-rc3
+require github.com/Diarkis/diarkis v1.0.0


### PR DESCRIPTION
`v1.0.0` タグをうつために diarkis のバージョンを `v1.0.0` にしました