### PR TITLE
fix: User status is now reset with an empty or false value when a new user created.

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -2,4 +2,4 @@ module github.com/Diarkis/diarkis-server-template
 
 go 1.22
 
-require github.com/Diarkis/diarkis v1.0.0-rc1-p2
+require github.com/Diarkis/diarkis v1.0.0-rc1-p3

--- a/src/k8s/gcp/base/udp/deploy.yaml
+++ b/src/k8s/gcp/base/udp/deploy.yaml
@@ -54,24 +54,29 @@ spec:
             privileged: true
       containers:
         - name: udp
+          # Configure Probes: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
           startupProbe:
             exec:
               command:
                 - sh
                 - -c
                 - "/go/bin/health-check $(cat /tmp/DIARKIS_MESH_ADDR) mars && /go/bin/health-check $(cat /tmp/DIARKIS_PUBLIC_ADDR) out"
-          readinessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - "/go/bin/health-check $(cat /tmp/DIARKIS_MESH_ADDR) in && /go/bin/health-check $(cat /tmp/DIARKIS_PUBLIC_ADDR) out"
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 5
           livenessProbe:
             exec:
               command:
                 - sh
                 - -c
                 - "/go/bin/health-check $(cat /tmp/DIARKIS_MESH_ADDR) in && /go/bin/health-check $(cat /tmp/DIARKIS_PUBLIC_ADDR) out"
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 5
           securityContext:
             runAsUser: 1000
             readOnlyRootFilesystem: true

--- a/src/lib/onlinestatus/main.go
+++ b/src/lib/onlinestatus/main.go
@@ -88,6 +88,9 @@ func getStorage() *dive.Storage {
 func setUserAsOnline(userData *user.User) {
 	us := userStatus.New()
 	us.SetAsString("UID", userData.ID)
+	us.SetAsBool("InRoom", false)
+	usd := userSessionData.New()
+	us.SetAsBytes("SessionData", usd.Pack())
 	err := getStorage().SetEx(userData.ID, us.Pack(), userStatusTTL)
 	if err != nil {
 		logger.Error("Failed to set user as online: UID:%s Error:%v", userData.ID, err.Error())


### PR DESCRIPTION
ユーザーが作成された直後にオンラインステータス API を実行した際に、 panic が発生する不具合を修正しました
- `user.OnNew` から呼ばれる `setUserAsOnline` にて、UID だけでなく、 `InRoom` や `SessionData` など他の値を空値または false でセットするようにしました
- UDP pod の deployment において、 readinessProbe を削除したのと、それぞれの Probe 設定値を追加しました
  - failureThreshold はデフォルトの `3` -> `5` に増やしました

```
http: panic serving 10.193.0.63:48566: runtime error: index out of range [1] with length 0
goroutine 230559689 [running]:
net/http.(*conn).serve.func1()
	net/http/server.go:1898 +0xbe
panic({0x8936a0?, 0xc01310e780?})
	runtime/panic.go:770 +0x132
encoding/binary.bigEndian.Uint16(...)
	encoding/binary/binary.go:143
github.com/Diarkis/diarkis/td.unpackProperty({0xc002e5c5f4, 0x0, 0x1}, 0x0, {{0x831b40?, 0xc0000aa1f8?}, 0x3860dc0?})
	github.com/Diarkis/diarkis@v1.0.0-rc1-p3/td/main.go:1257 +0x165d
github.com/Diarkis/diarkis/td.(*TransportData).Unpack(0xc003870080, {0xc002e5c5f4, 0x0, 0x1})
	github.com/Diarkis/diarkis@v1.0.0-rc1-p3/td/main.go:897 +0x145
output/lib/onlinestatus.getUserStatus({0xc002e5c5cc, 0x29, 0x29})
	output/lib/onlinestatus/main.go:173 +0x534
output/lib/onlinestatus.GetUserStatusList({0xc003778e40, 0x6, 0x975110?})
	output/lib/onlinestatus/main.go:235 +0xbac
output/cmds/http.getOnlineStatusList(0xc014364730, 0xc009f6d838?, 0x5?, 0xc00492de40)
	output/cmds/http/onlinestatus.go:31 +0x6a
github.com/Diarkis/diarkis/server/http.callHandler({0xc0027b8088, 0x1, 0x1}, 0x0, 0xc014364730, 0xc00492de00, 0xc00290c048)
	github.com/Diarkis/diarkis@v1.0.0-rc1-p3/server/http/http.go:593 +0x1f5
github.com/Diarkis/diarkis/server/http.callHandlers({0x9827d0, 0xc002e541c0}, 0xc005a8c240)
	github.com/Diarkis/diarkis@v1.0.0-rc1-p3/server/http/http.go:572 +0xc2d
net/http.HandlerFunc.ServeHTTP(0xc02880?, {0x9827d0?, 0xc002e541c0?}, 0x67559a?)
	net/http/server.go:2166 +0x29
net/http.(*ServeMux).ServeHTTP(0x46d139?, {0x9827d0, 0xc002e541c0}, 0xc005a8c240)
	net/http/server.go:2683 +0x1ad
net/http.serverHandler.ServeHTTP({0xc004b773b0?}, {0x9827d0?, 0xc002e541c0?}, 0x6?)
	net/http/server.go:3137 +0x8e
net/http.(*conn).serve(0xc003804090, {0x982d18, 0xc0029001b0})
	net/http/server.go:2039 +0x5e8
created by net/http.(*Server).Serve in goroutine 37
	net/http/server.go:3285 +0x4b4
```