### PR TITLE
build: corrected container path for Artifact Registry and fix README.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -102,6 +102,10 @@ push-container-aws: auth-docker-aws ## Push container to AWS
 setup-gcp: ## Set up GCP
 	./script/setup_gcp.sh
 
+.PHONY: auth-docker-gcp
+auth-docker-gcp: ## Authenticate docker to push images to GCP
+	gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
+
 .PHONY: build-container-gcp
 build-container-gcp: build-linux ## Build container for GCP
 	docker build --platform=linux/amd64 -f docker/http/Dockerfile remote_bin -t asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/http
@@ -110,16 +114,15 @@ build-container-gcp: build-linux ## Build container for GCP
 	docker build --platform=linux/amd64 -f docker/mars/Dockerfile remote_bin -t  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/mars
 
 .PHONY: push-container-gcp
-push-container-gcp: ## Push container to GCP
-	docker push  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/http
-	docker push  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/udp
-	docker push  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/tcp
-	docker push  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/mars
+push-container-gcp: auth-docker-gcp ## Push container to GCP
+	docker push  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/diarkis/http
+	docker push  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/diarkis/udp
+	docker push  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/diarkis/tcp
+	docker push  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/diarkis/mars
 
 .PHONY: setup-azure
 setup-azure: ## Set up Azure
 	./script/setup_azure.sh
-
 
 .PHONY: build-container-azure
 build-container-azure: build-linux ## Build container for azure

--- a/src/Makefile
+++ b/src/Makefile
@@ -108,10 +108,10 @@ auth-docker-gcp: ## Authenticate docker to push images to GCP
 
 .PHONY: build-container-gcp
 build-container-gcp: build-linux ## Build container for GCP
-	docker build --platform=linux/amd64 -f docker/http/Dockerfile remote_bin -t asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/http
-	docker build --platform=linux/amd64 -f docker/udp/Dockerfile remote_bin -t  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/udp
-	docker build --platform=linux/amd64 -f docker/tcp/Dockerfile remote_bin -t  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/tcp
-	docker build --platform=linux/amd64 -f docker/mars/Dockerfile remote_bin -t  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/mars
+	docker build --platform=linux/amd64 -f docker/http/Dockerfile remote_bin -t asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/diarkis/http
+	docker build --platform=linux/amd64 -f docker/udp/Dockerfile remote_bin -t  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/diarkis/udp
+	docker build --platform=linux/amd64 -f docker/tcp/Dockerfile remote_bin -t  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/diarkis/tcp
+	docker build --platform=linux/amd64 -f docker/mars/Dockerfile remote_bin -t  asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/diarkis/mars
 
 .PHONY: push-container-gcp
 push-container-gcp: auth-docker-gcp ## Push container to GCP

--- a/src/cloud/gcp/README.md
+++ b/src/cloud/gcp/README.md
@@ -37,17 +37,28 @@ gcloud compute --project=$PROJECT_NAME firewall-rules create diarkis-ingress-all
 
 network tag は diarkis という名前で設定していきます
 
-## インフラ構築手順2 - GCR,CloudDNS の有効化及び設定
+## インフラ構築手順2 - Artifact Registry API, CloudDNS の有効化及び設定
 
-GCR は Diarkis のコンテナイメージを配置する場所として今回使用しますので、有効化と Docker の設定を行います。
-またCloudDNSはkubernetesクラスターで使用するので、有効化します。
-まず https://console.cloud.google.com/flows/enableapi?apiid=containerregistry.googleapis.com にアクセスして対象プロジェクトの GCR API を有効化します。
-次に、https://console.cloud.google.com/flows/enableapi?apiid=dns にアクセスしてCloudDNSを有効化します。
-そして、有効化したGCRに対してアクセスが通るように下記コマンドを実行します。
+Artifact Registry は Diarkis のコンテナイメージを配置する場所として今回使用しますので、有効化と Docker の設定を行います。
+また CloudDNS は kubernetes クラスターで使用するので、有効化します。
 
+1. https://console.cloud.google.com/marketplace/product/google/artifactregistry.googleapis.com にアクセスして対象プロジェクトの Artifact Registry API を有効化します。
+2. https://console.cloud.google.com/flows/enableapi?apiid=dns にアクセスして CloudDNS を有効化します。
+3. 有効化した Artifact Registry に対してアクセスが通るように下記コマンドを実行します。
+
+```bash
+gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
 ```
-gcloud auth configure-docker # docker が gcloud を使って認証するように設定する
-```
+
+4. Artifact Registry に標準リポジトリを作成します。
+
+- 名前には `diarkis` と入力
+- 形式は `Docker` を選択
+- モードは `標準` を選択
+- ロケーションタイプは `リージョン` , ロケーションは `asia-northeast1` を選択
+- その他の設定はデフォルトを選択
+
+> 上記は asia-northeast1 に Artifact Registry を作成するための設定です。異なるロケーション・またはマルチリージョンに配置したい場合は場合は適宜修正してください。
 
 ## インフラ構築手順3 - GKE クラスタの作成(by web console)
 

--- a/src/cloud/gcp/README.md
+++ b/src/cloud/gcp/README.md
@@ -13,7 +13,7 @@ GKE で Diarkis を動作させるためのインフラの構築手順及び、K
 下記の手順でインフラの構築手順を述べていきます。
 
 1. firewall の作成
-2. GCRとCloudDNS の有効化
+2. Artifact Registry と CloudDNS の有効化
 3. GKE クラスタの作成
 4. GKE への接続
 5. manifest の修正
@@ -37,9 +37,9 @@ gcloud compute --project=$PROJECT_NAME firewall-rules create diarkis-ingress-all
 
 network tag は diarkis という名前で設定していきます
 
-## インフラ構築手順2 - Artifact Registry API, CloudDNS の有効化及び設定
+## インフラ構築手順2 - Artifact Registry と CloudDNS の有効化及び設定
 
-Artifact Registry は Diarkis のコンテナイメージを配置する場所として今回使用しますので、有効化と Docker の設定を行います。
+Artifact Registry を Diarkis のコンテナイメージを配置する場所として利用するために、有効化と Docker の設定を行います。
 また CloudDNS は kubernetes クラスターで使用するので、有効化します。
 
 1. https://console.cloud.google.com/marketplace/product/google/artifactregistry.googleapis.com にアクセスして対象プロジェクトの Artifact Registry API を有効化します。
@@ -58,7 +58,7 @@ gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
 - ロケーションタイプは `リージョン` , ロケーションは `asia-northeast1` を選択
 - その他の設定はデフォルトを選択
 
-> 上記は asia-northeast1 に Artifact Registry を作成するための設定です。異なるロケーション・またはマルチリージョンに配置したい場合は場合は適宜修正してください。
+> 上記は asia-northeast1 に Artifact Registry を作成するための設定です。異なるロケーションまたはマルチリージョンに配置したい場合は適宜修正してください。
 
 ## インフラ構築手順3 - GKE クラスタの作成(by web console)
 

--- a/src/k8s/gcp/base/kustomization.yaml
+++ b/src/k8s/gcp/base/kustomization.yaml
@@ -22,16 +22,16 @@ resources:
 
 images:
   - name: udp
-    newName: asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/udp
+    newName: asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/diarkis/udp
     newTag: latest
   - name: tcp
-    newName: asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/tcp
+    newName: asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/diarkis/tcp
     newTag: latest
   - name: mars
-    newName: asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/mars
+    newName: asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/diarkis/mars
     newTag: latest
   - name: http
-    newName: asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/http
+    newName: asia-northeast1-docker.pkg.dev/__GCP_PROJECT_ID__/diarkis/http
     newTag: latest
 
 configMapGenerator:


### PR DESCRIPTION
GCP の Manifest にて Artifact Registry のパスを利用するようになっていたが、階層が足りなかったので修正しました
- `[location]/[project ID]/[Repository]/[image]` の形式に修正しました
  - e.g. `asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/http` -> `asia-northeast1-docker.pkg.dev/$(GCP_PROJECT_ID)/diarkis/http`
- GCP の README が非推奨である Container Registry を使う説明になっていたので Artifact Registry を利用する手順に修正しました
- `make push-container-gcp` にてイメージを push するまえに Artifact Registry に認証するようにしました