### PR TITLE
HTTP grace period to 600

### DIFF
--- a/src/k8s/aws/base/http/deploy.yaml
+++ b/src/k8s/aws/base/http/deploy.yaml
@@ -19,7 +19,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 600
       initContainers:
         - image: alpine:latest
           name: tuner

--- a/src/k8s/azure/base/http/deploy.yaml
+++ b/src/k8s/azure/base/http/deploy.yaml
@@ -19,7 +19,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 600
       initContainers:
         - image: alpine:latest
           name: tuner

--- a/src/k8s/gcp/base/http/deploy.yaml
+++ b/src/k8s/gcp/base/http/deploy.yaml
@@ -22,7 +22,7 @@ spec:
         ad.datadoghq.com/nginx.instances: '[{"nginx_status_url": "http://%%host%%:8080/nginx_status"}]'
         ad.datadoghq.com/nginx.logs: '[{"source": "nginx", "service": "nginx"}]'
     spec:
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 600
       initContainers:
         - image: alpine:latest
           name: tuner

--- a/src/k8s/linode/base/http/deploy.yaml
+++ b/src/k8s/linode/base/http/deploy.yaml
@@ -23,7 +23,7 @@ spec:
         ad.datadoghq.com/nginx.instances: '[{"nginx_status_url": "http://%%host%%:8080/nginx_status"}]'
         ad.datadoghq.com/nginx.logs: '[{"source": "nginx", "service": "nginx"}]'
     spec:
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 600
       initContainers:
         - image: alpine:latest
           name: tuner


### PR DESCRIPTION
Now the server-template uses HTTP nodes as the Dive storage by default, we should have sufficient time to shutdown