### PR TITLE
correct podmonitoring interval

### DIFF
--- a/src/k8s/gcp/base/podmonitoring.yaml
+++ b/src/k8s/gcp/base/podmonitoring.yaml
@@ -9,4 +9,4 @@ spec:
   endpoints:
     - port: http
       path: /metrics/prometheus/v/3
-      interval: 2s
+      interval: 5s


### PR DESCRIPTION
`2s` was too short
https://cloud.google.com/stackdriver/docs/managed-prometheus/troubleshooting
> The minimum scrape interval supported by Managed Service for Prometheus is 5 seconds.
