### PR TITLE
rewrite import in go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ help:
 COPYRIGHT := Diarkis Inc. All rights reserved.
 
 .PHONY: init
-init: ## make init project_id={project ID} builder_token={build token} output={absolute path to install}
-	./init.sh $(project_id) $(builder_token) $(output)
+init: ## make init project_id={project ID} builder_token={build token} output={absolute path to install} module_name={go module name}
+	./init.sh $(project_id) $(builder_token) $(output) $(module_name)
 
 .PHONY: fmt
 fmt: add-license

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ To generate it, use the following command.
 
 `make init project_id={project ID} builder_token={build token} output={absolute path to install}`
 
+or to use a custom module name
+
+`make init project_id={project ID} builder_token={build token} output={absolute path to install} module_name=github.com/sample-organization/sample-project`
+
 The repository itself is under the src directory.
 When you actually start using this repository, it is assumed that you will start your project using the src directory as a template.
 To generate it, use the following command.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To generate it, use the following command.
 
 or to use a custom module name
 
-`make init project_id={project ID} builder_token={build token} output={absolute path to install} module_name=github.com/sample-organization/sample-project`
+`make init project_id={project ID} builder_token={build token} output={absolute path to install} module_name={custom module name}`
 
 The repository itself is under the src directory.
 When you actually start using this repository, it is assumed that you will start your project using the src directory as a template.

--- a/init.sh
+++ b/init.sh
@@ -58,7 +58,6 @@ pushd ${tmp_dir}
         exit 1
     fi
 popd
-rm -fr "$tmp_dir"
 
 go run ./tools/install.go $project_id $builder_token $output_path
 go run ./tools/rewrite_import.go $output_path "github.com/Diarkis/diarkis-server-template" "$module_name"

--- a/init.sh
+++ b/init.sh
@@ -5,22 +5,32 @@ function usage {
 $(basename ${0}) is a generate diarkis project tool.
 
 Usage:
-    $(basename ${0}) moduleName builderToken outputPath
+    $(basename ${0}) projectID builderToken outputPath <moduleName optional>
 Sample:
-    $(basename ${0}) github.com/sample-origanization/sample-project sampleToken /tmp/sample-project
+    $(basename ${0}) 012345678 sampleToken /tmp/sample-project
+    or
+    $(basename ${0}) 012345678 sampleToken /tmp/sample-project github.com/sample-origanization/sample-project
 
 EOF
     exit 1
 }
 
-if [ $# -ne 3 ]; then
+# Accept optional module name
+if [ $# -ne 3 -a $# -ne 4 ]; then
     usage
+fi
+
+if [ $# -eq 4 ]; then
+    module_name=$4
 fi
 
 project_id=$1
 builder_token=$2
 output_path=$3
-module_name=$(basename $output_path)
+if [ -z "${module_name}" ]; then
+    module_name=$(basename $output_path)
+fi
+
 go run ./tools/install.go $project_id $builder_token $output_path
 pushd $output_path
     go mod edit -module $module_name

--- a/init.sh
+++ b/init.sh
@@ -15,6 +15,8 @@ EOF
     exit 1
 }
 
+CURR_PWD=`pwd`
+
 # Accept optional module name
 if [ $# -ne 3 -a $# -ne 4 ]; then
     usage
@@ -30,6 +32,33 @@ output_path=$3
 if [ -z "${module_name}" ]; then
     module_name=$(basename $output_path)
 fi
+
+# check module name using go mod init
+tmp_dir=
+
+cleanup() {
+    cd ${CURR_PWD}
+    if [ ! -z "$tmp_dir" ]; then
+        rm -fr "$tmp_dir"
+    fi
+}
+
+trap cleanup EXIT
+
+tmp_dir=`mktemp -d -q`
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+    echo "fail to create temporary directory"
+    exit 1
+fi
+
+pushd ${tmp_dir}
+    go mod init ${module_name}
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
+popd
+rm -fr "$tmp_dir"
 
 go run ./tools/install.go $project_id $builder_token $output_path
 go run ./tools/rewrite_import.go $output_path "github.com/Diarkis/diarkis-server-template" "$module_name"

--- a/init.sh
+++ b/init.sh
@@ -9,7 +9,7 @@ Usage:
 Sample:
     $(basename ${0}) 012345678 sampleToken /tmp/sample-project
     or
-    $(basename ${0}) 012345678 sampleToken /tmp/sample-project github.com/sample-origanization/sample-project
+    $(basename ${0}) 012345678 sampleToken /tmp/sample-project github.com/sample-organization/sample-project
 
 EOF
     exit 1

--- a/init.sh
+++ b/init.sh
@@ -32,18 +32,8 @@ if [ -z "${module_name}" ]; then
 fi
 
 go run ./tools/install.go $project_id $builder_token $output_path
+go run ./tools/rewrite_import.go $output_path "github.com/Diarkis/diarkis-server-template" "$module_name"
 pushd $output_path
     go mod edit -module $module_name
-    if [ $(uname) == 'Darwin' ]; then
-        find . -type f -name '*.go'  -exec sed -i '' -e "s%github.com/Diarkis/diarkis-server-template%$module_name%g" {} \;
-        sed -i '' -e "s%github.com/Diarkis/diarkis-server-template%$module_name%g" puffer/gen.sh
-    elif [ "$(expr substr $(uname -s) 1 5)" == 'Linux' ]; then
-        find . -type f -name '*.go'  -exec sed -i -e "s%github.com/Diarkis/diarkis-server-template%$module_name%g" {} \;
-        sed -i -e "s%github.com/Diarkis/diarkis-server-template%$module_name%g" puffer/gen.sh
-        echo "Linux"
-    else
-        echo "Unsupported OS"
-        uname -a
-        exit 1
-    fi
+    echo "PROJECT_NAME=$module_name" > puffer/vars.sh
 popd

--- a/src/puffer/gen.sh
+++ b/src/puffer/gen.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+source ${SCRIPT_DIR}/vars.sh
+
+PUFFER_BIN=
 if [ $(uname) == 'Darwin' ]; then
-    ./puffer-mac . . github.com/Diarkis/diarkis-server-template/puffer/go
+    PUFFER_BIN=./puffer-mac
 elif [ "$(expr substr $(uname -s) 1 5)" == 'Linux' ]; then
-    ./puffer-linux . . github.com/Diarkis/diarkis-server-template/puffer/go
+    PUFFER_BIN=./puffer-linux
+else
+    echo "unsupported platform"
+    exit 1
 fi
+
+${PUFFER_BIN} . . ${PROJECT_NAME}/puffer/go
 go fmt ./go/...

--- a/src/puffer/vars.sh
+++ b/src/puffer/vars.sh
@@ -1,0 +1,1 @@
+PROJECT_NAME=github.com/Diarkis/diarkis-server-template/puffer/go

--- a/tools/rewrite_import.go
+++ b/tools/rewrite_import.go
@@ -1,3 +1,5 @@
+// © 2019-2024 Diarkis Inc. All rights reserved.
+
 package main
 
 import (

--- a/tools/rewrite_import.go
+++ b/tools/rewrite_import.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) != 4 {
+		fmt.Printf("usage %s: <target_dir> <oldImport> <newImport>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	targetDir := os.Args[1]
+	oldImport := os.Args[2]
+	newImport := os.Args[3]
+	err := processDir(targetDir, oldImport, newImport)
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func processDir(dir, oldImport, newImport string) error {
+	err := filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			fmt.Printf("prevent panic by handling failure accessing a path %q: %v\n", path, err)
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		ext := filepath.Ext(info.Name())
+		if ext != ".go" {
+			return nil
+		}
+
+		fixedStr, rewrote, err := fixImport(path, oldImport, newImport)
+		if err != nil {
+			return err
+		}
+		if rewrote {
+			err = os.WriteFile(path, []byte(fixedStr), info.Mode())
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return err
+}
+
+func fixImport(filename, oldImport, newImport string) (string, bool, error) {
+	fset := token.NewFileSet()
+
+	expr, err := parser.ParseFile(fset, filename, nil, parser.Mode(0))
+	if err != nil {
+		return "", false, err
+	}
+
+	found := false
+	for _, imp := range expr.Imports {
+		if strings.HasPrefix(imp.Path.Value[1:], oldImport) {
+			// rewrite import
+			imp.Path.Value = strings.Replace(imp.Path.Value, oldImport, newImport, 1)
+			found = true
+		}
+	}
+
+	var buf strings.Builder
+
+	// write into buf
+	if err := format.Node(&buf, token.NewFileSet(), expr); err != nil {
+		return "", false, err
+	}
+
+	return buf.String(), found, nil
+}


### PR DESCRIPTION
Before this PR the go module name was based on the output path.
go does not work well with module name not in the form of xxx/yyy/zzz.
- Update the makefile and init.sh script to support a fourth optional parameter to specify a go module name to use.
- Rewrite the go import with a go tool. This remove the dependency on find/sed.
- Add a dedicated file to define the project name in puffer. It is now easier to
  change the name without modifying the puffer gen.sh script.

TODO: update README