### PR TITLE
Randomise Empty Searches

### DIFF
--- a/src/cmds/matchmaker/main.go
+++ b/src/cmds/matchmaker/main.go
@@ -20,12 +20,14 @@ func Setup() {
 	// Set up matching ticket with sampleTicketType
 	// This callback is invoked when a new ticket is issued.
 	matching.SetOnIssueTicket(sampleTicketType0, func(userData *user.User) *matching.TicketParams {
+		searchTries := util.RandomInt(1, 300)
+		emptySearches := util.RandomInt(1, searchTries)
 		return &matching.TicketParams{
 			ProfileIDs:     []string{"RankMatch"},
 			MaxMembers:     2,
 			SearchInterval: 100, // 100ms
-			SearchTries:    uint8(util.RandomInt(0, 300)),
-			EmptySearches:  3,
+			SearchTries:    uint8(searchTries),
+			EmptySearches:  uint8(emptySearches),
 			TicketDuration: 60, // 1m
 			HowMany:        20,
 			// Change here as you see fit according to your application needs
@@ -74,12 +76,14 @@ func Setup() {
 	})
 
 	matching.SetOnIssueTicket(sampleTicketType1, func(userData *user.User) *matching.TicketParams {
+		searchTries := util.RandomInt(1, 300)
+		emptySearches := util.RandomInt(1, searchTries)
 		return &matching.TicketParams{
 			ProfileIDs:     []string{"RankMatch20"},
 			MaxMembers:     4,
 			SearchInterval: 100, // 100ms
-			SearchTries:    uint8(util.RandomInt(0, 300)),
-			EmptySearches:  3,
+			SearchTries:    uint8(searchTries),
+			EmptySearches:  uint8(emptySearches),
 			TicketDuration: 60, // 1m
 			HowMany:        20,
 			// Change here as you see fit according to your application needs

--- a/src/cmds/matchmaker/main.go
+++ b/src/cmds/matchmaker/main.go
@@ -20,6 +20,7 @@ func Setup() {
 	// Set up matching ticket with sampleTicketType
 	// This callback is invoked when a new ticket is issued.
 	matching.SetOnIssueTicket(sampleTicketType0, func(userData *user.User) *matching.TicketParams {
+		// Randomize searchTries and emptySearches to not move to the wait mode at the same time considering all clients issue tickets at the same time.
 		searchTries := util.RandomInt(1, 300)
 		emptySearches := util.RandomInt(1, searchTries)
 		return &matching.TicketParams{
@@ -76,6 +77,7 @@ func Setup() {
 	})
 
 	matching.SetOnIssueTicket(sampleTicketType1, func(userData *user.User) *matching.TicketParams {
+		// Randomize searchTries and emptySearches to not move to the wait mode at the same time considering all clients issue tickets at the same time.
 		searchTries := util.RandomInt(1, 300)
 		emptySearches := util.RandomInt(1, searchTries)
 		return &matching.TicketParams{


### PR DESCRIPTION
Randomised emptySearches for all ticket types considering clients issue the ticket at the same time. (they won't match as they move to the add mode at the same time)