### PR TITLE
add license header with a go script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,4 @@ fmt: add-license
 
 .PHONY: add-license ## add license header to all go files
 add-license: $(shell find . -type f -name '*.go')
-	for f in $^; do \
-		head -n 1 "$$f" | grep -q '$(COPYRIGHT)' && tail -n +2 "$$f" > temp && mv temp "$$f"; \
-		head -n 1 "$$f" | grep -q '^$$' && tail -n +2 "$$f" > temp && mv temp "$$f"; \
-		echo "// © 2019-$(shell date +%Y) $(COPYRIGHT)\n" | cat - "$$f" > temp && mv temp "$$f"; \
-	done
+	go run ./tools/add_license.go

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ help:
 ## Set default command of make to help, so that running make will output help texts
 .DEFAULT_GOAL := help
 
-COPYRIGHT := Diarkis Inc. All rights reserved.
-
 .PHONY: init
 init: ## make init project_id={project ID} builder_token={build token} output={absolute path to install} module_name={go module name}
 	./init.sh $(project_id) $(builder_token) $(output) $(module_name)

--- a/tools/add_license.go
+++ b/tools/add_license.go
@@ -1,0 +1,109 @@
+// © 2019-2024 Diarkis Inc. All rights reserved.
+
+//go:build ignore
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const copyRightHeader = "Diarkis Inc. All rights reserved."
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	year := time.Now().Year()
+	headerWithYear := fmt.Sprintf("// © 2019-%d %s\n\n", year, copyRightHeader)
+
+	err := filepath.Walk(".", func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			fmt.Printf("prevent panic by handling failure accessing a path %q: %v\n", path, err)
+			return err
+		}
+
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		ext := filepath.Ext(info.Name())
+		if !strings.EqualFold(ext, ".go") {
+			return nil
+		}
+
+		found, err := hasCopyrightHeader(path)
+		if err != nil {
+			return err
+		}
+		if found {
+			return nil
+		}
+
+		err = addCopyrightHeader(path, headerWithYear)
+		return err
+	})
+
+	if err != nil {
+		return 1
+	}
+
+	return 0
+}
+
+func hasCopyrightHeader(filename string) (bool, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	fileScanner := bufio.NewScanner(f)
+
+	fileScanner.Split(bufio.ScanLines)
+
+	// check the first line only
+	for fileScanner.Scan() {
+		if strings.Contains(fileScanner.Text(), copyRightHeader) {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	return false, nil
+}
+
+func addCopyrightHeader(filename string, headerWithYear string) error {
+	// Try to keep the same permissions.
+	stat, err := os.Stat(filename)
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	b := bytes.NewBuffer(nil)
+	b.Grow(len(data) + len(headerWithYear))
+	_, _ = b.WriteString(headerWithYear)
+	_, _ = b.Write(data)
+
+	// write to a temp file and rename it.
+	// same as what did the Makefile previously.
+	const tempFilename = "temp"
+	err = os.WriteFile(tempFilename, b.Bytes(), stat.Mode())
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(tempFilename, filename)
+}


### PR DESCRIPTION
Improve overhaul portability.