### PR TITLE
build: added ms(mars-stats) to linux build settings.

### DIFF
--- a/src/build/linux-build.yml
+++ b/src/build/linux-build.yml
@@ -23,6 +23,9 @@ buildSettings:
     health-check:
       target: healthcheck/main.go
       output: remote_bin/health-check
+    ms:
+      target: mars-stats/main.go
+      output: remote_bin/ms
     testcli:
       target: testcli/main.go
       output: remote_bin/testcli


### PR DESCRIPTION
mac build では ms (mars-stats) を build しているが、 linux build ではしていなかったので追加しました。