### PR TITLE
build: use `go mod edit` instead of `go list -m` because cannot acces…

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ help:
 ## Set default command of make to help, so that running make will output help texts
 .DEFAULT_GOAL := help
 
-DIARKIS_VERSION = $(shell go list -m github.com/Diarkis/diarkis | cut -d " " -f 2)
+DIARKIS_VERSION = $(shell go mod edit -json | jq -r '.Require[] | select(.Path | contains("github.com/Diarkis/diarkis")).Version')
 DIARKIS_CLI = ./diarkis-cli/os/linux/bin/diarkis-cli
 BUILD_CONFIG = ./build/linux-build.yml
 AWS_ACCOUNT_NUM = __AWS_ACCOUNT_NUM__


### PR DESCRIPTION
…s private repository.

```
$ go list -m 
go: github.com/Diarkis/diarkis@v1.1.0-alpha4: invalid version: git ls-remote -q origin in /root/go/pkg/mod/cache/vcs/xxxxx: exit status 128:
	fatal: could not read Username for 'https://github.com': terminal prompts disabled

$  go mod edit -json
{
	"Module": {
		"Path": "xxxxxxxx"
	},
	"Go": "1.22",
	"Require": [
		{
			"Path": "github.com/Diarkis/diarkis",
			"Version": "v1.1.0-alpha4"
		}
	],
	"Exclude": null,
	"Replace": null,
	"Retract": null
}
```