### PR TITLE
build: added some paths to .buildignore

### DIFF
--- a/src/.buildignore
+++ b/src/.buildignore
@@ -14,3 +14,11 @@ coderefs/*
 configs/*
 # docker
 docker/*
+docker-compose.yml
+# git
+.git/*
+.github/*
+.gitignore
+# IDE
+.vscode/*
+.idea/*


### PR DESCRIPTION
Added paths that should be excluded to .buildignore

Paths that are added when you manage with git after exporting it, etc.