### PR TITLE
fix: change `searchTries` range for ticketType 0 and 1 from 1 to 50

### DIFF
--- a/src/cmds/matchmaker/main.go
+++ b/src/cmds/matchmaker/main.go
@@ -22,7 +22,7 @@ func Setup() {
 	// This callback is invoked when a new ticket is issued.
 	matching.SetOnIssueTicket(sampleTicketType0, func(userData *user.User) *matching.TicketParams {
 		// Randomize searchTries and emptySearches to not move to the wait mode at the same time considering all clients issue tickets at the same time.
-		searchTries := util.RandomInt(1, 300)
+		searchTries := util.RandomInt(1, 50) // max 50 tries for 5 seconds (searchInterval * searchTries)
 		emptySearches := util.RandomInt(1, searchTries)
 		return &matching.TicketParams{
 			ProfileIDs:     []string{"RankMatch"},
@@ -79,7 +79,7 @@ func Setup() {
 
 	matching.SetOnIssueTicket(sampleTicketType1, func(userData *user.User) *matching.TicketParams {
 		// Randomize searchTries and emptySearches to not move to the wait mode at the same time considering all clients issue tickets at the same time.
-		searchTries := util.RandomInt(1, 300)
+		searchTries := util.RandomInt(1, 50) // max 50 tries for 5 seconds (searchInterval * searchTries)
 		emptySearches := util.RandomInt(1, searchTries)
 		return &matching.TicketParams{
 			ProfileIDs:     []string{"RankMatch20"},


### PR DESCRIPTION
ticketType 2 は既に 1-50 としていますが、 ticketType 0,1 についても合わせたいです。

`SearchInterval=100`, `searchTries=1-300` だと add state に変更になるまでに最大 30 秒かかります。
そのため、初回のマッチングまでに最大 30 秒掛かる可能性があるため、
実用上は `searchTries=1-50` として最大 5 秒としたほうが適切と考えます。

これにより各 ticketType の違いは、
- ticketType 0: max member 2
- ticketType 1: max member 4
- ticketType 2: max member 8

となります。