### PR TITLE
eks: upgrade kubernetes version to 1.32

### DIFF
--- a/src/cloud/aws/cluster_config.yaml
+++ b/src/cloud/aws/cluster_config.yaml
@@ -4,7 +4,7 @@ kind: ClusterConfig
 metadata:
   name: diarkis
   region: ap-northeast-1
-  version: "1.29"
+  version: "1.32"
 vpc:
   clusterEndpoints:
     privateAccess: true

--- a/src/k8s/aws/base/kustomization.yaml
+++ b/src/k8s/aws/base/kustomization.yaml
@@ -44,6 +44,10 @@ configMapGenerator:
       - shared/conf/dive.json
       - shared/conf/room.json
 
+  - name: mesh-conf-public
+    files:
+      - shared/conf/public/mesh.json
+
   - name: http-conf
     files:
       - http/conf/main.json

--- a/src/k8s/aws/base/kustomization.yaml
+++ b/src/k8s/aws/base/kustomization.yaml
@@ -46,7 +46,10 @@ configMapGenerator:
 
   - name: mesh-conf-public
     files:
+      # Assuming use of Nitro based instances
       - shared/conf/public/mesh.json
+      # If you are using a non Nitro based instance, use eth0
+      # - shared/conf/mesh.json
 
   - name: http-conf
     files:

--- a/src/k8s/aws/base/shared/conf/public/mesh.json
+++ b/src/k8s/aws/base/shared/conf/public/mesh.json
@@ -1,0 +1,5 @@
+{
+  "nic": "ens5",
+  "marsAddress": "mars.base.svc.cluster.local",
+  "marsPort": "6779"
+}

--- a/src/k8s/aws/base/tcp/deploy.yaml
+++ b/src/k8s/aws/base/tcp/deploy.yaml
@@ -120,8 +120,12 @@ spec:
         alpha.eksctl.io/nodegroup-name: diarkis-public
       volumes:
         - name: shared-conf
-          configMap:
-            name: shared-conf
+          projected:
+            sources:
+              - configMap:
+                  name: shared-conf
+              - configMap:
+                  name: mesh-conf-public
         - name: tcp-conf
           configMap:
             name: tcp-conf

--- a/src/k8s/aws/base/udp/deploy.yaml
+++ b/src/k8s/aws/base/udp/deploy.yaml
@@ -115,8 +115,12 @@ spec:
         alpha.eksctl.io/nodegroup-name: diarkis-public
       volumes:
         - name: shared-conf
-          configMap:
-            name: shared-conf
+          projected:
+            sources:
+              - configMap:
+                  name: shared-conf
+              - configMap:
+                  name: mesh-conf-public
         - name: udp-conf
           configMap:
             name: udp-conf

--- a/src/k8s/aws/overlays/dev0/kustomization.yaml
+++ b/src/k8s/aws/overlays/dev0/kustomization.yaml
@@ -31,6 +31,11 @@ configMapGenerator:
       - shared/conf/dive.json
       - shared/conf/room.json
 
+  - name: mesh-conf-public
+    behavior: replace
+    files:
+      - shared/conf/public/mesh.json
+
   - name: http-conf
     behavior: replace
     files:

--- a/src/k8s/aws/overlays/dev0/shared/conf/public/mesh.json
+++ b/src/k8s/aws/overlays/dev0/shared/conf/public/mesh.json
@@ -1,0 +1,5 @@
+{
+  "nic": "ens5",
+  "marsAddress": "mars.dev0.svc.cluster.local",
+  "marsPort": "6779"
+}


### PR DESCRIPTION
Upgraded kubernetes to 1.32 because 1.29 is not now standard supports.
Along with that, the NIC for UDP and TCP changed from `eth0` to `ens5`.
So I added the mesh configuration file for them and apply to their manifests using [projected volumes](https://kubernetes.io/docs/concepts/storage/projected-volumes/).