### PR TITLE
Remove unused -c option from k8s deployments

### DIFF
--- a/src/k8s/aws/base/tcp/deploy.yaml
+++ b/src/k8s/aws/base/tcp/deploy.yaml
@@ -104,9 +104,6 @@ spec:
               value: "600"
           command:
             - /go/bin/tcp
-          args:
-            - -c
-            - "1"
           volumeMounts:
             - mountPath: /configs/tcp
               name: tcp-conf

--- a/src/k8s/aws/base/udp/deploy.yaml
+++ b/src/k8s/aws/base/udp/deploy.yaml
@@ -99,9 +99,6 @@ spec:
               value: "600"
           command:
             - /go/bin/udp
-          args:
-            - -c
-            - "1"
           volumeMounts:
             - mountPath: /configs/shared
               name: shared-conf

--- a/src/k8s/azure/base/tcp/deploy.yaml
+++ b/src/k8s/azure/base/tcp/deploy.yaml
@@ -100,9 +100,6 @@ spec:
               value: "600"
           command:
             - /go/bin/tcp
-          args:
-            - -c
-            - "1"
           volumeMounts:
             - mountPath: /configs/tcp
               name: tcp-conf

--- a/src/k8s/azure/base/udp/deploy.yaml
+++ b/src/k8s/azure/base/udp/deploy.yaml
@@ -99,9 +99,6 @@ spec:
               value: "600"
           command:
             - /go/bin/udp
-          args:
-            - -c
-            - "1"
           volumeMounts:
             - mountPath: /configs/shared
               name: shared-conf

--- a/src/k8s/gcp/base/tcp/deploy.yaml
+++ b/src/k8s/gcp/base/tcp/deploy.yaml
@@ -101,9 +101,6 @@ spec:
               value: "600"
           command:
             - /go/bin/tcp
-          args:
-            - -c
-            - "1"
           volumeMounts:
             - mountPath: /configs/tcp
               name: tcp-conf

--- a/src/k8s/gcp/base/udp/deploy.yaml
+++ b/src/k8s/gcp/base/udp/deploy.yaml
@@ -98,9 +98,6 @@ spec:
               value: "600"
           command:
             - /go/bin/udp
-          args:
-            - -c
-            - "1"
           volumeMounts:
             - mountPath: /configs/shared
               name: shared-conf


### PR DESCRIPTION
## Summary
- remove `-c 1` arguments from TCP and UDP deployments

## Testing
- `go test ./...`