### PR TITLE
Fix duplicate room owner sync push

### DIFF
--- a/src/cmds/room/main.go
+++ b/src/cmds/room/main.go
@@ -47,8 +47,6 @@ func afterCreateRoom(ver uint8, cmd uint16, payload []byte, userData *user.User,
 		return
 	}
 	setupOnJoinCallback(roomID)
-	ownerID := room.GetRoomOwnerID(roomID)
-	syncRoomOwnerID(roomID, ownerID)
 }
 
 func afterRandomJoin(ver uint8, cmd uint16, payload []byte, userData *user.User, next func(error)) {
@@ -74,7 +72,12 @@ func setupOnJoinCallback(roomID string) {
 			// there is no owner yet...
 			return
 		}
-		syncRoomOwnerID(roomID, ownerID)
+		if ud.ID == ownerID {
+			// the owner already received the notification
+			return
+		}
+		// send the current owner ID only to the user who just joined
+		ud.ServerPush(ver, onRoomOwnerChangeCmd, []byte(ownerID), true)
 	})
 }
 


### PR DESCRIPTION
## Summary
- ensure room owner sync only sends once
- syncRoomOwnerID was called 3 times from the followings:
  - onRoomOwnerChange
  - afterCreateRoom
  - setupOnJoinCallback
- It's enough to set just onRoomOwnerChange because its callback is called from create room, join room and change room owner.

## Testing
- `go vet ./...`
- `go test ./...`

## references
- https://github.com/Diarkis/diarkis/issues/2849