### PR TITLE
src: make puffer gen print stderr

### DIFF
--- a/src/magefiles/magefiles.go
+++ b/src/magefiles/magefiles.go
@@ -151,6 +151,7 @@ func (Puffer) Gen() error {
 	cmd = exec.Command(pufferBin, ".", ".", doc.Module.Path+"/puffer/go")
 	cmd.Dir = "puffer"
 	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
 	return cmd.Run()
 }


### PR DESCRIPTION
In case of puffer generation error it was hard to tell
what failed because stderr was not logged.
