### PR TITLE
roomsupport and groupsupport module is loaded by diarkisexec duplicately.

### DIFF
--- a/src/cmds/http/main.go
+++ b/src/cmds/http/main.go
@@ -2,21 +2,13 @@
 
 package httpcmds
 
-import (
-	"github.com/Diarkis/diarkis/groupsupport" // if you do not need group module, comment out this line
-	"github.com/Diarkis/diarkis/roomsupport"  // if you do not need room module, comment out this line
-	"github.com/Diarkis/diarkis/server/http"
-)
+import "github.com/Diarkis/diarkis/server/http"
 
 func Expose() {
 	// this is a sample HTTP request handler
 	http.Get("/hello", handleHello)
 	// if you do not need HTTP-based match making comment out this line
 	exposeMatchMaker()
-	// if you do not need room module, comment out this line
-	roomsupport.DefineRoomSupport()
-	// if you do not need group module, comment out this line
-	groupsupport.DefineGroupSupport()
 	// custom room operations
 	exposeRoom()
 	// custom user online status


### PR DESCRIPTION
fix #93 
roomsupport and groupsupport module was loaded by diarkisexec and cmds/http/main.go duplicately.
```
[2025/07/01 16:45:26.451]<MATCH>       ERROR    Duplicate profile ID is not allowed ProfileID=randomRoomMatching
```

1. location where it was loaded in func Expose() in cmds/http/main.go
```
func Expose() {
...
roomsupport.DefineRoomSupport()
...
groupsupport.DefineGroupSupport()
```

2. location where it was loaded in func setupModules() in diarkisexec/main.go 
```
	if modules.Room != nil {
		// Always call room setup dive
		room.SetupWithDive(getConfigPath(modules.Room.ConfigPath))

		if len(httpServerConfig) != 0 {
			// for HTTP server setup of Room
			room.Setup()
			roomsupport.DefineRoomSupport()
		} else {
			// for UDP or TCP server setup of Room
			room.Setup()
			if modules.Room.ExposeCommands {
				room.ExposeCommands()
				roomsupport.ExposeCommands()
			}
		}
	}
```