### PR TITLE
fix confusing comment

### DIFF
--- a/src/cmds/http/main.go
+++ b/src/cmds/http/main.go
@@ -9,6 +9,8 @@ func Expose() {
 	http.Get("/hello", handleHello)
 	// if you do not need HTTP-based match making comment out this line
 	exposeMatchMaker()
+	// define match maker profiles
+	defineMatchMakerRules()
 	// custom room operations
 	exposeRoom()
 }

--- a/src/cmds/http/matching.go
+++ b/src/cmds/http/matching.go
@@ -17,7 +17,6 @@ func exposeMatchMaker() {
 	http.Post("/mm/add/:mmID/:uniqueID/:ttl", addToMatchMaker)
 	http.Delete("/mm/rm/:mmID", removeFromMatchMaker)
 	http.Post("/mm/search/:mmIDs/:limit", searchMatchMaker)
-	defineMatchMakerRules()
 }
 
 func defineMatchMakerRules() {


### PR DESCRIPTION
- if you remove `exposeMatchMaker` from http by following the comment, moching.Define() will be also removed then you cannot use matncing feature.
