### PR TITLE
build: bump up diarkis v1.3.0

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 toolchain go1.24.0
 
-require github.com/Diarkis/diarkis v1.3.0-rc1
+require github.com/Diarkis/diarkis v1.3.0
 
 require (
 	github.com/magefile/mage v1.15.0

--- a/src/go.mod
+++ b/src/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 toolchain go1.24.0
 
-require github.com/Diarkis/diarkis v1.2.4
+require github.com/Diarkis/diarkis v1.3.0-rc1
 
 require (
 	github.com/magefile/mage v1.15.0


### PR DESCRIPTION
## Summary
Update Diarkis version to `v1.3.0-rc1` in `src/go.mod`.

## Test Plan
- [x] `make init` creates a new project with `v1.3.0-rc1` dependency.
- [x] `make build-local` succeeds in the generated project.
- [x] `make server target=http` starts the server successfully.