### PR TITLE
build: bump up diarkis to v1.3.3

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 toolchain go1.24.0
 
-require github.com/Diarkis/diarkis v1.3.3-rc1
+require github.com/Diarkis/diarkis v1.3.3
 
 require (
 	github.com/magefile/mage v1.15.0


### PR DESCRIPTION
## Summary

- `src/go.mod` の `github.com/Diarkis/diarkis` を `v1.3.3-rc1` から `v1.3.3` に更新

## Test plan

- [x] CI lint workflow が通ること（init テスト、kustomize build、フォーマットチェック）

🤖 Generated with [Claude Code](https://claude.com/claude-code)