### PR TITLE
build: bump up diarkis to v1.3.4

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 toolchain go1.24.0
 
-require github.com/Diarkis/diarkis v1.3.3
+require github.com/Diarkis/diarkis v1.3.4
 
 require (
 	github.com/magefile/mage v1.15.0


### PR DESCRIPTION
## Summary
- Upgrade Diarkis dependency from v1.3.3 to v1.3.4
- Verified remote build succeeds (all 8 binaries built successfully)
- Verified MARS server starts and runs correctly with v1.3.4

## Test plan
- [x] `make build-local` — all binaries (bot, health-check, http, mars, ms, tcp, testcli, udp) built successfully
- [x] MARS server startup confirmed with `Version:1.3.4` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)