### PR TITLE
bump diarkis to v1.3.9

### DIFF
--- a/src/build/linux-build.yml
+++ b/src/build/linux-build.yml
@@ -1,7 +1,7 @@
 buildSettings:
   root: ..
   version: "2"
-  goVersion: 1.24.0
+  goVersion: 1.26.3
   env:
     CGO_ENABLED: 0
     CGO_CFLAGS: -I${PROJECT_DIR}

--- a/src/build/mac-build.yml
+++ b/src/build/mac-build.yml
@@ -1,7 +1,7 @@
 buildSettings:
   root: ..
   version: "2"
-  goVersion: 1.24.0
+  goVersion: 1.26.3
   env:
     GOOS: darwin
     GOARCH: arm64 # if you use intel mac, replace from arm64 to amd64

--- a/src/build/windows-build.yml
+++ b/src/build/windows-build.yml
@@ -1,7 +1,7 @@
 buildSettings:
   root: ..
   version: "2"
-  goVersion: 1.24.0
+  goVersion: 1.26.3
   env:
     CGO_ENABLED: 0
     CGO_CFLAGS: -I${PROJECT_DIR}

--- a/src/go.mod
+++ b/src/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 toolchain go1.26.3
 
-require github.com/Diarkis/diarkis v1.3.8
+require github.com/Diarkis/diarkis v1.3.9
 
 require (
 	github.com/magefile/mage v1.15.0

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,8 +1,8 @@
 module github.com/Diarkis/diarkis-server-template
 
-go 1.24
+go 1.26
 
-toolchain go1.24.0
+toolchain go1.26.3
 
 require github.com/Diarkis/diarkis v1.3.8
 

--- a/src/go.mod
+++ b/src/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 toolchain go1.24.0
 
-require github.com/Diarkis/diarkis v1.3.6
+require github.com/Diarkis/diarkis v1.3.8
 
 require (
 	github.com/magefile/mage v1.15.0


### PR DESCRIPTION
## 概要

Diarkis エンジンを `v1.3.6` から `v1.3.9` にバージョンアップします。

> 当初 v1.3.8 で PR を作成しましたが、レビュー（#discussion_r3321102703）で v1.3.9 にする提案を受けて反映しました。

## 変更内容

- `src/go.mod`: `github.com/Diarkis/diarkis` を `v1.3.6` → `v1.3.9`
- `src/go.mod`: `go 1.24` → `go 1.26`、`toolchain go1.24.0` → `go1.26.3`
- `src/build/{mac,linux,windows}-build.yml`: `goVersion: 1.24.0` → `1.26.3`

> diarkis v1.3.8+ はビルド時に `go >= 1.26` を要求するため、Go バージョン関連も合わせて更新しています。

`go.sum` は対象外（コミットしない運用）。

## ビルド確認

`make build-local`（リモートビルダー `v3.builder.diarkis.io`）で全バイナリのビルド成功を確認済み（v1.3.9 で再検証）。

- bot / health-check / http / mars / ms / tcp / testcli / udp → すべて `ExitCode:0`
- goVersion 明示後は `switching to go1.26.x` の警告も解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)