### PR TITLE
bump diarkis to v1.4.0-rc1

### DIFF
--- a/examples/csar/dgs/README.md
+++ b/examples/csar/dgs/README.md
@@ -249,12 +249,11 @@ kubectl edit deploy dgs -n dev0
 
 ```yaml
 # Edit the cpu: item and save
-: resources:
-    limits:
-      cpu: 800m
-    requests:
-      cpu: 800m
-:
+resources:
+  limits:
+    cpu: 800m
+  requests:
+    cpu: 800m
 ```
 
 ### Pod Count Configuration
@@ -349,11 +348,13 @@ kubectl edit scaledobject dgs -n dev0
 
 ```yaml
 # Edit items and save
-: maxReplicaCount: 300
-  minReplicaCount: 10
-: scalingModifiers:
-    formula: takenCnt + 10
-:
+maxReplicaCount: 300
+minReplicaCount: 10
+```
+
+```yaml
+scalingModifiers:
+  formula: takenCnt + 10
 ```
 
 ### Node Count Configuration

--- a/examples/csar/dgs/README.md
+++ b/examples/csar/dgs/README.md
@@ -249,12 +249,11 @@ kubectl edit deploy dgs -n dev0
 
 ```yaml
 # Edit the cpu: item and save
-:
-        resources:
-          limits:
-            cpu: 800m
-          requests:
-            cpu: 800m
+: resources:
+    limits:
+      cpu: 800m
+    requests:
+      cpu: 800m
 :
 ```
 
@@ -350,12 +349,10 @@ kubectl edit scaledobject dgs -n dev0
 
 ```yaml
 # Edit items and save
-:
-  maxReplicaCount: 300
+: maxReplicaCount: 300
   minReplicaCount: 10
-:
-    scalingModifiers:
-      formula: takenCnt + 10
+: scalingModifiers:
+    formula: takenCnt + 10
 :
 ```
 

--- a/src/go.mod
+++ b/src/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 toolchain go1.26.3
 
-require github.com/Diarkis/diarkis v1.3.9
+require github.com/Diarkis/diarkis v1.4.0-rc1
 
 require (
 	github.com/magefile/mage v1.15.0


### PR DESCRIPTION
## 概要

`github.com/Diarkis/diarkis` を `v1.3.9` → `v1.4.0-rc1` に更新します。

## 変更内容

- `src/go.mod` の diarkis バージョンを `v1.4.0-rc1` に更新

## Go バージョン

変更不要。`v1.4.0-rc1` の go.mod は `go 1.26` / `toolchain go1.26.1` を要求しており、テンプレート側の `go 1.26` / `toolchain go1.26.3`(および各 `*-build.yml` の `goVersion: 1.26.3`)で既に満たされています。

## 動作確認

- `make build-local` で全ターゲット（http / mars / udp / tcp / bot / testcli / health-check / ms）が `ExitCode:0` でビルド成功することを確認

## 備考

- `make gen` を実行すると puffer 生成コードと一部 README に既存のフォーマットドリフト差分が出ますが、これらは diarkis バージョンアップとは無関係（ローカルの puffer バイナリ / prettier バージョン差異に起因）のため本 PR には含めていません。