### PR TITLE
bump diarkis to v1.4.0

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 toolchain go1.26.3
 
-require github.com/Diarkis/diarkis v1.4.0-rc1
+require github.com/Diarkis/diarkis v1.4.0
 
 require (
 	github.com/magefile/mage v1.15.0


### PR DESCRIPTION
## 概要

diarkis 依存を `v1.4.0-rc1` (リリース候補) から `v1.4.0` (正式リリース) に更新します。

## 変更内容

- `src/go.mod`: `github.com/Diarkis/diarkis` を `v1.4.0-rc1` → `v1.4.0`

## ビルド検証

`make build-local`（diarkis-cli v3.2.0 / remote builder `v3.builder.diarkis.io` 経由）で全ターゲットのビルドが成功しました。

| ターゲット | 結果 |
|-----------|------|
| bot | ✅ ExitCode:0 |
| health-check | ✅ ExitCode:0 |
| http | ✅ ExitCode:0 |
| mars | ✅ ExitCode:0 |
| ms | ✅ ExitCode:0 |
| tcp | ✅ ExitCode:0 |
| testcli | ✅ ExitCode:0 |
| udp | ✅ ExitCode:0 |

- `go mod edit` で解決されるバージョンが `v1.4.0` であることを確認済み
- ビルド時に一時注入した `project_id` / `builder_token`（build/mac-build.yml）は検証後に復元済み（コミットされていません）

## 備考

- `make fmt` 実行済み（フォーマット差分なし）
- `go.sum` はコミットしていません（diarkis-cli でのビルドのため & プロジェクトルール）

🤖 Generated with [Claude Code](https://claude.com/claude-code)