### PR TITLE
bump diarkis to v1.4.1

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 toolchain go1.26.3
 
-require github.com/Diarkis/diarkis v1.4.0
+require github.com/Diarkis/diarkis v1.4.1
 
 require (
 	github.com/magefile/mage v1.15.0


### PR DESCRIPTION
## 概要

diarkis の依存を `v1.4.0` から `v1.4.1` に更新します。

変更は [src/go.mod](src/go.mod) の 1 行のみです。

## Go バージョン要件

v1.4.0 と v1.4.1 で diarkis 側の `go.mod` は完全に同一のため、テンプレート側の Go 要件の変更は不要です。

| | v1.4.0 | v1.4.1 |
|---|---|---|
| go | 1.26 | 1.26 |
| toolchain | go1.26.1 | go1.26.1 |
| golang.org/x/net | v0.55.0 | v0.55.0 |
| golang.org/x/sys | v0.45.0 | v0.45.0 |

テンプレートは go 1.26 / toolchain go1.26.3 なので、いずれも満たしています。

## 動作確認

クリーンな `make init` + `make build-local` で確認済みです。

- **ビルド**: 6 バイナリすべて `ExitCode:0`（http, mars, ms, tcp, testcli, udp）
- **起動**: MARS / HTTP / UDP すべて `Version:1.4.1 GoModVersion:v1.4.1` で起動し、mesh network ready を確認
- **疎通**: Go test client で HTTP 認証 → UDP ハンドシェイク成功
- **room create**: ルーム生成成功、`room get info` で `Current Members: 1/10`, `owner ID: "1234567890"` を確認

なお `go.sum` はリポジトリの方針どおりコミットしていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)